### PR TITLE
Add mkinitcpio hooks so encrypted bcachefs root volumes can be unlocked at boot

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -15,9 +15,13 @@ pkgbase = linux-bcachefs
 	source = git+https://evilpiepirate.org/git/bcachefs.git
 	source = config.x86_64
 	source = linux-bcachefs.preset
+	source = bcachefs-install
+	source = bcachefs-hooks
 	sha256sums = SKIP
 	sha256sums = 320e08a384b740a6c16720afca4bae8944305f5f2a92c1ff98812b29c3d9d833
 	sha256sums = 438f8d252439949a995dadef0e26f6a178433b3c3dca78901ee9708212bda729
+	sha256sums = c5fa40d26374851e989b0b6277830048f604ede910c993fef20172d055db8cbe
+	sha256sums = 54197d403c946c229a14e1d624d4606dcb1ab5a928322d0625362a28387ca892
 
 pkgname = linux-bcachefs
 	pkgdesc = The Linux kernel and modules (with bcachefs support)

--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,5 +1,5 @@
 pkgbase = linux-bcachefs
-	pkgver = 4.15.r15242.g9b233320cdbe
+	pkgver = 4.15.r44211.gd9bf5460deb7
 	pkgrel = 1
 	url = https://bcachefs.org/
 	arch = x86_64
@@ -21,7 +21,7 @@ pkgbase = linux-bcachefs
 	sha256sums = 320e08a384b740a6c16720afca4bae8944305f5f2a92c1ff98812b29c3d9d833
 	sha256sums = 438f8d252439949a995dadef0e26f6a178433b3c3dca78901ee9708212bda729
 	sha256sums = c5fa40d26374851e989b0b6277830048f604ede910c993fef20172d055db8cbe
-	sha256sums = 54197d403c946c229a14e1d624d4606dcb1ab5a928322d0625362a28387ca892
+	sha256sums = 7fd132485c829da6d48bc38c7c57e6296574e8e571f2dccb67196951f54c04ef
 
 pkgname = linux-bcachefs
 	pkgdesc = The Linux kernel and modules (with bcachefs support)

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -18,10 +18,14 @@ source=('git+https://evilpiepirate.org/git/bcachefs.git'
         # the main kernel config files
         'config.x86_64'
         # standard config files for mkinitcpio ramdisk
-        "${pkgbase}.preset")
+        "${pkgbase}.preset"
+        "bcachefs-install"
+        "bcachefs-hooks")
 sha256sums=('SKIP'
             '320e08a384b740a6c16720afca4bae8944305f5f2a92c1ff98812b29c3d9d833'
-            '438f8d252439949a995dadef0e26f6a178433b3c3dca78901ee9708212bda729')
+            '438f8d252439949a995dadef0e26f6a178433b3c3dca78901ee9708212bda729'
+            'c5fa40d26374851e989b0b6277830048f604ede910c993fef20172d055db8cbe'
+            '54197d403c946c229a14e1d624d4606dcb1ab5a928322d0625362a28387ca892')
 
 _kernelname=${pkgbase#linux}
 
@@ -125,6 +129,22 @@ _package() {
 
   # add System.map
   install -D -m644 System.map "${pkgdir}/boot/System.map-${_kernver}"
+
+  # add /etc/initcpio/install/bcachefs
+  install -D -m644 bcachefs-install "${pkgdir}/etc/initcpio/install/bcachefs"
+
+  # add /etc/initcpio/hooks/bcachefs
+  install -D -m644 bcachefs-hooks "${pkgdir}/etc/initcpio/hooks/bcachefs"
+
+  # edit /etc/mkinitcpio.conf to include bcachefs hooks if it doesn't already
+  # and create a backup of original at /etc/mkinitcpio.conf.bak
+  if ! grep -rnw '/etc/mkinitcpio.conf' -e 'bcachefs' >/dev/null 2>&1; then
+    echo "creating /etc/mkinitcpio.conf.bak and adding bcachefs hook to /etc/mkinitcpio.conf"
+    sed -i.bak 's/keyboard/bcachefs &/g' /etc/mkinitcpio.conf
+  else
+    echo "/etc/mkinitcpio.conf already contains bcachefs hook"
+  fi
+
 }
 
 _package-headers() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -136,15 +136,6 @@ _package() {
   # add /etc/initcpio/hooks/bcachefs
   install -D -m644 bcachefs-hooks "${pkgdir}/etc/initcpio/hooks/bcachefs"
 
-  # edit /etc/mkinitcpio.conf to include bcachefs hooks if it doesn't already
-  # and create a backup of original at /etc/mkinitcpio.conf.bak
-  if ! grep -rnw '/etc/mkinitcpio.conf' -e 'bcachefs' >/dev/null 2>&1; then
-    echo "creating /etc/mkinitcpio.conf.bak and adding bcachefs hook to /etc/mkinitcpio.conf"
-    sed -i.bak 's/keyboard/bcachefs &/g' /etc/mkinitcpio.conf
-  else
-    echo "/etc/mkinitcpio.conf already contains bcachefs hook"
-  fi
-
 }
 
 _package-headers() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@
 
 pkgbase=linux-bcachefs
 _srcname=bcachefs
-pkgver=4.15.r15242.g9b233320cdbe
+pkgver=4.15.r44211.gd9bf5460deb7
 pkgrel=1
 arch=('x86_64')
 url="https://bcachefs.org/"
@@ -25,7 +25,7 @@ sha256sums=('SKIP'
             '320e08a384b740a6c16720afca4bae8944305f5f2a92c1ff98812b29c3d9d833'
             '438f8d252439949a995dadef0e26f6a178433b3c3dca78901ee9708212bda729'
             'c5fa40d26374851e989b0b6277830048f604ede910c993fef20172d055db8cbe'
-            '54197d403c946c229a14e1d624d4606dcb1ab5a928322d0625362a28387ca892')
+            '7fd132485c829da6d48bc38c7c57e6296574e8e571f2dccb67196951f54c04ef')
 
 _kernelname=${pkgbase#linux}
 
@@ -131,10 +131,10 @@ _package() {
   install -D -m644 System.map "${pkgdir}/boot/System.map-${_kernver}"
 
   # add /etc/initcpio/install/bcachefs
-  install -D -m644 bcachefs-install "${pkgdir}/etc/initcpio/install/bcachefs"
+  install -D -m644 "${srcdir}/bcachefs-install" "${pkgdir}/etc/initcpio/install/bcachefs"
 
   # add /etc/initcpio/hooks/bcachefs
-  install -D -m644 bcachefs-hooks "${pkgdir}/etc/initcpio/hooks/bcachefs"
+  install -D -m644 "${srcdir}/bcachefs-hooks" "${pkgdir}/etc/initcpio/hooks/bcachefs"
 
 }
 

--- a/bcachefs-hooks
+++ b/bcachefs-hooks
@@ -1,34 +1,7 @@
 #!/usr/bin/ash
 
 run_hook() {
-    #echo "running sleep before checking for unlock"
-    #sleep 5
-    #echo "test for getting root name"
-    #echo "root is:  $root"
-    #echo "checking for /dev/null"
-    #if [ ! -f /dev/null ]; then
-    #	echo "/dev/null does not exist" 
-    #	echo "creating /dev/null"
-    #	mknod /dev/null c 1 3
-    #	echo "checking if /dev/null creating succeeded"
-    #	if [ ! -f /dev/null ]; then
-    #		echo "creation of /dev/null failed"
-    #	else
-    #		echo "creation of /dev/null succeeded"
-    #	fi
-    #	else
-    #	echo "/dev/null exists"
-    #fi
-    #echo "checking if bcachefs binary exists"
-    #if [ ! hash bcachefs >/dev/null ]; then
-    #	echo "bcachefs binary does not exist"
-    #else 
-    #	echo "bcachefs binary exists"
-    #fi
-
-    #echo "ROOT is: $ROOT"
-    # check if disk needs unlocking
-    if bcachefs unlock -c $root >/dev/null 2>&1; then
+   if bcachefs unlock -c $root >/dev/null 2>&1; then
     	echo "Unlocking $root:"
     
     	while true; do
@@ -38,15 +11,6 @@ run_hook() {
 
     echo "running fsck.bcachefs on $root:"
     fsck.bcachefs $root
-
-    # the '-c' flag for bcachefs does not yet exist
-    # simply prompt for unlock since we know it's 
-    # an ecrypted drive. Change this when the '-c'
-    # is available for bcachefs
-    #echo "Unlocking $root:"
-    #while true; do
-    # 	bcachefs unlock $root && break
-    #done
 }
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/bcachefs-hooks
+++ b/bcachefs-hooks
@@ -1,0 +1,52 @@
+#!/usr/bin/ash
+
+run_hook() {
+    #echo "running sleep before checking for unlock"
+    #sleep 5
+    #echo "test for getting root name"
+    #echo "root is:  $root"
+    #echo "checking for /dev/null"
+    #if [ ! -f /dev/null ]; then
+    #	echo "/dev/null does not exist" 
+    #	echo "creating /dev/null"
+    #	mknod /dev/null c 1 3
+    #	echo "checking if /dev/null creating succeeded"
+    #	if [ ! -f /dev/null ]; then
+    #		echo "creation of /dev/null failed"
+    #	else
+    #		echo "creation of /dev/null succeeded"
+    #	fi
+    #	else
+    #	echo "/dev/null exists"
+    #fi
+    #echo "checking if bcachefs binary exists"
+    #if [ ! hash bcachefs >/dev/null ]; then
+    #	echo "bcachefs binary does not exist"
+    #else 
+    #	echo "bcachefs binary exists"
+    #fi
+
+    #echo "ROOT is: $ROOT"
+    # check if disk needs unlocking
+    if bcachefs unlock -c $root >/dev/null 2>&1; then
+    	echo "Unlocking $root:"
+    
+    	while true; do
+    		bcachefs unlock $root && break
+    	done
+    fi
+
+    echo "running fsck.bcachefs on $root:"
+    fsck.bcachefs $root
+
+    # the '-c' flag for bcachefs does not yet exist
+    # simply prompt for unlock since we know it's 
+    # an ecrypted drive. Change this when the '-c'
+    # is available for bcachefs
+    #echo "Unlocking $root:"
+    #while true; do
+    # 	bcachefs unlock $root && break
+    #done
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/bcachefs-install
+++ b/bcachefs-install
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+build() {
+
+	#add_module 'bcachefs'
+	add_binary "bcachefs"
+	add_binary "fsck.bcachefs"
+
+	add_runscript
+}
+
+help() {
+
+	cat <<HELPEOF
+This hook is for setting the bcachefs unlock prompt at boot
+HELPEOF
+}
+
+# vim set ft=sh ts=4 sw=4 et:


### PR DESCRIPTION
This mkinitcpio hook is necessary for booting an encrypted bcachefs root volume. It checks if the root volume is encrypted, and if so prompts the user for a passphrase to unlock the volume. I've adapted it from the [bcachefs-tools initramfs scripts](https://github.com/thoughtpolice/bcachefs-tools/tree/master/initramfs). Currently the hook supports unlocking from a TTY. I don't have plymouth installed, so support will need to be added and tested in the future for plymouth users.